### PR TITLE
Make sse stream send the entire lynt data instead of only the id

### DIFF
--- a/src/routes/MainPage.svelte
+++ b/src/routes/MainPage.svelte
@@ -88,9 +88,8 @@
 		if (currentTab === tabs[2]) {
 			const eventSource = new EventSource('/api/sse');
 			eventSource.onmessage = async (event) => {
-				const newLyntId = JSON.parse(event.data);
-
-				await renderLyntAtTop(newLyntId);
+				// Render the entire lynt data to not fetch the lynt each time
+				await renderLyntAtTop(JSON.parse(event.data));
 			};
 		}
 	}
@@ -228,9 +227,8 @@
 		}
 	});
 
-	async function renderLyntAtTop(lyntId: string) {
-		const lyntData = await getLynt(lyntId);
-		feed = [lyntData].concat(feed);
+	async function renderLyntAtTop(lynt: FeedItem) {
+		feed = [lynt].concat(feed);
 	}
 	function handlePaste(event: ClipboardEvent) {
 		event.preventDefault();

--- a/src/routes/api/lynt/+server.ts
+++ b/src/routes/api/lynt/+server.ts
@@ -119,7 +119,7 @@ export const POST: RequestHandler = async ({
 
 		const [newLynt] = await db.insert(lynts).values(lyntValues).returning();
 
-		sendMessage(uniqueLyntId);
+		sendMessage(newLynt);
 
 		return json(newLynt, { status: 201 });
 	} catch (error) {


### PR DESCRIPTION
Read title, this makes the sse stream available at `https://lyntr.com/api/sse` sending more than the new lynt id.
Why do this you may ask? If you used the sse stream for monitoring new lynts, you would need to request the lynt using an http request each time to view the content or the user who posted it. Sending the entire lynt data will allow us to not fetch the lynt data using http each time. (if it broke i aint responsible ok ty man)

love, body