### PR TITLE
fix question results being forced to be true

### DIFF
--- a/src/routes/api/profile/+server.ts
+++ b/src/routes/api/profile/+server.ts
@@ -29,7 +29,7 @@ let questions: Question[] = [
 	{
 		id: 'CatQuestion',
 		condition: (input: any) => {
-			return Boolean(input) === true ? -2 : 1;
+			return input === "true" ? -2 : 1;
 		}
 	},
 	{
@@ -83,7 +83,7 @@ let questions: Question[] = [
 	{
 		id: 'Dexerto',
 		condition: (input: any) => {
-			return Boolean(input) == true ? -25 : 25;
+			return input === "true" ? -25 : 25;
 		}
 	},
 	{
@@ -101,19 +101,19 @@ let questions: Question[] = [
 	{
 		id: 'AudioRick',
 		condition: (input: any) => {
-			return Boolean(input) ? -13 : 5;
+			return input === "true" ? -13 : 5;
 		}
 	},
 	{
 		id: 'Degree',
 		condition: (input: any) => {
-			return Boolean(input) ? 0 : -5;
+			return input === "true" ? 0 : -5;
 		}
 	},
 	{
 		id: 'AudioAgeOfWar',
 		condition: (input: any) => {
-			return Boolean(input) ? 15 : -5;
+			return input === "true" ? 15 : -5;
 		}
 	},
 	{
@@ -125,19 +125,19 @@ let questions: Question[] = [
 	{
 		id: 'Kubernete',
 		condition: (input: any) => {
-			return Boolean(input) ? -3 : 0;
+			return input === "true" ? -3 : 0;
 		}
 	},
 	{
 		id: 'ReactionImage',
 		condition: (input: any) => {
-			return Boolean(input) ? -10 : 5;
+			return input === "true" ? -10 : 5;
 		}
 	},
 	{
 		id: 'GimmickAccount',
 		condition: (input: any) => {
-			return Boolean(input) ? -5 : 5;
+			return input === "true" ? -5 : 5;
 		}
 	}
 ];


### PR DESCRIPTION
any string that isn't empty will result in `true` being returned by `Boolean()`
![image](https://github.com/user-attachments/assets/52dc3c90-8e71-49bf-87d6-417a667cb304)

by simply comparing the string to "true" this problem will be fixed
![image](https://github.com/user-attachments/assets/1cfb36f8-517d-4932-935e-d5ffe00a947e)
